### PR TITLE
Fix 'Redundant conformance of 'ExpenseLog' to protocol 'Identifiable'…

### DIFF
--- a/Shared/Views/Models/ExpenseLog+Extension.swift
+++ b/Shared/Views/Models/ExpenseLog+Extension.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreData
 
-extension ExpenseLog: Identifiable {
+extension ExpenseLog {
     
     var categoryEnum: Category {
         Category(rawValue: category ?? "") ?? .other


### PR DESCRIPTION
This removes the build error in the latest version of Xcode (12.4)